### PR TITLE
Add WoW health bar addon

### DIFF
--- a/WoW_HP_Bar/Config.lua
+++ b/WoW_HP_Bar/Config.lua
@@ -1,0 +1,69 @@
+local addonName, HPBar = ...
+local Config = {}
+HPBar.Config = Config
+
+local panel
+
+local function CreateSlider(name, parent, minVal, maxVal, step, text)
+    local slider = CreateFrame("Slider", name, parent, "OptionsSliderTemplate")
+    slider:SetMinMaxValues(minVal, maxVal)
+    slider:SetValueStep(step)
+    slider:SetObeyStepOnDrag(true)
+    _G[slider:GetName() .. 'Low']:SetText(tostring(minVal))
+    _G[slider:GetName() .. 'High']:SetText(tostring(maxVal))
+    _G[slider:GetName() .. 'Text']:SetText(text)
+    return slider
+end
+
+function Config:CreateOptions()
+    panel = CreateFrame("Frame", "HPBarOptionsPanel", UIParent)
+    panel.name = "HP Bar"
+
+    local title = panel:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+    title:SetPoint("TOPLEFT", 16, -16)
+    title:SetText("HP Bar Configuration")
+
+    local widthSlider = CreateSlider("HPBarWidthSlider", panel, 50, 400, 1, "Width")
+    widthSlider:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -40)
+    widthSlider:SetValue(HPBarDB.width)
+    widthSlider:SetScript("OnValueChanged", function(self, value)
+        HPBarDB.width = value
+        HPBar.ApplySettings()
+    end)
+
+    local heightSlider = CreateSlider("HPBarHeightSlider", panel, 10, 50, 1, "Height")
+    heightSlider:SetPoint("TOPLEFT", widthSlider, "BOTTOMLEFT", 0, -30)
+    heightSlider:SetValue(HPBarDB.height)
+    heightSlider:SetScript("OnValueChanged", function(self, value)
+        HPBarDB.height = value
+        HPBar.ApplySettings()
+    end)
+
+    local colorBtn = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    colorBtn:SetSize(100, 22)
+    colorBtn:SetPoint("TOPLEFT", heightSlider, "BOTTOMLEFT", 0, -30)
+    colorBtn:SetText("Color")
+    colorBtn:SetScript("OnClick", function()
+        local function callback()
+            local r,g,b = ColorPickerFrame:GetColorRGB()
+            HPBarDB.color = {r=r, g=g, b=b}
+            HPBar.ApplySettings()
+        end
+        ColorPickerFrame.func = callback
+        ColorPickerFrame:SetColorRGB(HPBarDB.color.r, HPBarDB.color.g, HPBarDB.color.b)
+        ColorPickerFrame:Hide() -- Need to run the OnShow
+        ColorPickerFrame:Show()
+    end)
+
+    InterfaceOptions_AddCategory(panel)
+end
+
+function Config:Toggle()
+    if not panel then
+        self:CreateOptions()
+    end
+    InterfaceOptionsFrame_OpenToCategory(panel)
+    InterfaceOptionsFrame_OpenToCategory(panel)
+end
+
+return Config

--- a/WoW_HP_Bar/HPBar.lua
+++ b/WoW_HP_Bar/HPBar.lua
@@ -1,0 +1,66 @@
+local addonName, HPBar = ...
+
+HPBar.defaults = {
+    width = 200,
+    height = 20,
+    color = {r = 0, g = 1, b = 0},
+    point = {"CENTER", UIParent, "CENTER", 0, -200},
+}
+
+local db
+
+local frame = CreateFrame("StatusBar", "HPBarFrame", UIParent)
+frame:SetStatusBarTexture("Interface\\TARGETINGFRAME\\UI-StatusBar")
+frame:SetMinMaxValues(0, UnitHealthMax("player"))
+frame:SetValue(UnitHealth("player"))
+frame:SetReverseFill(true)
+frame:SetOrientation("HORIZONTAL")
+frame:SetMovable(true)
+frame:EnableMouse(true)
+frame:RegisterForDrag("LeftButton")
+frame:SetScript("OnDragStart", frame.StartMoving)
+frame:SetScript("OnDragStop", function(self)
+    self:StopMovingOrSizing()
+    local point, _, _, x, y = self:GetPoint()
+    db.point = {point, UIParent, point, x, y}
+end)
+
+local function ApplySettings()
+    frame:SetSize(db.width, db.height)
+    frame:SetStatusBarColor(db.color.r, db.color.g, db.color.b)
+    frame:ClearAllPoints()
+    frame:SetPoint(unpack(db.point))
+end
+HPBar.ApplySettings = ApplySettings
+
+frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+frame:RegisterEvent("UNIT_HEALTH")
+frame:SetScript("OnEvent", function(self, event, arg1)
+    if event == "UNIT_HEALTH" and arg1 ~= "player" then return end
+    self:SetMinMaxValues(0, UnitHealthMax("player"))
+    self:SetValue(UnitHealth("player"))
+end)
+
+SLASH_HPBAR1 = "/hp"
+SlashCmdList["HPBAR"] = function()
+    if HPBar.Config then
+        HPBar.Config:Toggle()
+    end
+end
+
+function HPBar:Initialize()
+    if not HPBarDB then
+        HPBarDB = CopyTable(self.defaults)
+    end
+    db = HPBarDB
+    ApplySettings()
+    frame:Show()
+    if HPBar.Minimap then
+        HPBar.Minimap:Create() -- create minimap icon if available
+    end
+end
+
+HPBar.frame = frame
+
+C_Timer.After(0, function() HPBar:Initialize() end)
+

--- a/WoW_HP_Bar/HPBar.toc
+++ b/WoW_HP_Bar/HPBar.toc
@@ -1,0 +1,10 @@
+## Interface: 11404
+## Title: HP Bar
+## Author: Example Author
+## Version: 1.0
+## Notes: Simple movable HP bar
+## SavedVariables: HPBarDB
+
+HPBar.lua
+Config.lua
+Minimap.lua

--- a/WoW_HP_Bar/Minimap.lua
+++ b/WoW_HP_Bar/Minimap.lua
@@ -1,0 +1,22 @@
+local addonName, HPBar = ...
+local MinimapMod = {}
+HPBar.Minimap = MinimapMod
+
+function MinimapMod:Create()
+    if self.button then return end
+    local button = CreateFrame("Button", "HPBarMinimapButton", Minimap)
+    button:SetSize(32,32)
+    button:SetFrameStrata("MEDIUM")
+    button:SetFrameLevel(8)
+    button:SetNormalTexture("Interface\\Icons\\INV_Misc_ArmorKit_15")
+    button:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
+    button:SetPoint("TOPLEFT", Minimap, "TOPLEFT")
+    button:SetScript("OnClick", function()
+        if HPBar.Config then
+            HPBar.Config:Toggle()
+        end
+    end)
+    self.button = button
+end
+
+return MinimapMod

--- a/WoW_HP_Bar/README.md
+++ b/WoW_HP_Bar/README.md
@@ -1,0 +1,19 @@
+# HP Bar Addon
+
+A simple movable health bar addon for World of Warcraft Classic Era.
+
+## Installation
+1. Copy the `WoW_HP_Bar` folder into your WoW `Interface/AddOns` directory.
+2. Launch the game and enable **HP Bar** from the addons list.
+
+## Usage
+- Type `/hp` in chat to open the configuration panel.
+- Drag the bar to move it. The position is saved automatically.
+
+## Customization
+In the options panel you can:
+- Adjust width and height.
+- Pick a bar color using the color button.
+- Click the minimap icon to quickly open the options.
+
+The addon stores settings per account in `HPBarDB`.


### PR DESCRIPTION
## Summary
- add `WoW_HP_Bar` addon folder
- implement `HPBar.lua` for a movable health bar and `/hp` command
- add configuration logic and minimap icon
- document installation and usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d55c910a88327bdf87b603968c12d